### PR TITLE
Adding support for In-app Messages

### DIFF
--- a/app/Request.js
+++ b/app/Request.js
@@ -1,18 +1,19 @@
 define(function() {
 
-	var Request = function(url, data, appKey, async) {
+	var Request = function(method, url, data, appKey, async) {
+		this.method = method;
 		this.url = url;
 		this.data = data || {};
 		this.appKey = appKey;
 		this.async = async;
 	};
 
-	Request.prototype.post = function(callback) {
+	Request.prototype.send = function(callback) {
 		var isIE = window.XDomainRequest ? true : false;
 		var data = JSON.stringify(this.data);
 		if (isIE) {
 			var xdr = new window.XDomainRequest();
-			xdr.open('POST', this.url, this.async);
+			xdr.open(this.method, this.url, this.async);
 			xdr.onload = function() {
 				callback(200, xdr.responseText);
 			};
@@ -28,7 +29,7 @@ define(function() {
 			xdr.send(data);
 		} else {
 			var xhr = new XMLHttpRequest();
-			xhr.open('POST', this.url, this.async);
+			xhr.open(this.method, this.url, this.async);
 			xhr.onreadystatechange = function() {
 				if (xhr.readyState === 4) {
 					callback(xhr.status, xhr.responseText);
@@ -38,6 +39,7 @@ define(function() {
 			xhr.setRequestHeader('Content-Type', 'application/json; charset=UTF-8');
 			xhr.send(data);
 		}
-	}
+	};
+
 	return Request;
 });

--- a/app/TdInAppMessage.js
+++ b/app/TdInAppMessage.js
@@ -218,9 +218,9 @@ define(function() {
 					bodyEl = '<div id="td-message-body" class="td-message-body">'+ titleEl + textEl + '</div>',
 					closeEl = '<div id="td-close-icon"><div class="close-x"></div></div>',
 					
-					// IF MESSAGE HAS ACTION > WRAP ALL BUT CLOSE IN <a>
+					// IF MESSAGE HAS ACTION > WRAP ALL BUT closeEl IN <a>
 					innerMessage = ( this.action&&this.action.type=='url' ) ?
-					'<a href="' + this.action.value +'" class="td-message-link">' + imgEl + bodyEl + '</a>' + closeEl: imgEl + bodyEl + closeEl ;
+					'<a href="' + this.action.value +'" id="td-message-link" class="td-message-link">' + imgEl + bodyEl + '</a>' + closeEl : imgEl + bodyEl + closeEl ;
 
 				// WRAP IN MSG CONTAINER AND SET AS innerHTML
 				messageEl.innerHTML = '<div id="td-message-container" class="td-message-container">' + innerMessage + '</div>';
@@ -281,11 +281,8 @@ define(function() {
 	        };
 
 	        var imgObj = new Image();
-	        imgObj.onload = _onload;
 	        imgObj.src = self.image_url;
-	        if (imgObj.complete) {
-	            _onload();
-	        }
+	        imgObj.onload = _onload;
 
 	    };
 
@@ -334,14 +331,9 @@ define(function() {
 				element.setAttribute('class', currentClass+' '+className);
 			};
 
-			var _setButtonPositions = function() {
-
-		    };
-
 		    // IF LAYOUT FULL SET VERTICAL HEIGHT AND BUTTONS BEFORESHOWING
 		    if ( self.layout == 'full' ) {
 		    	messageWrapper.setAttribute('style', 'height: '+ self.image_h +'px; width: '+ self.image_w +'px;' );
-		    	_setButtonPositions();
 		    }
 
 			setTimeout( function(){ 
@@ -359,12 +351,22 @@ define(function() {
 					_startDelayClose(); 
 				});
 
-				// ADD HIDE FUNCTION FOR CLOSE BUTTON
+				// ADD CLOSE FUNCTION FOR CLOSE BUTTON
 				var closeButton = messageEl.querySelector('#td-close-icon');
 				closeButton.addEventListener('click', function(e){
 					clearTimeout(delayClose);
 					_closeMessage();
 				});
+
+				//EVENT LISTENER FOR MESSAGE CLICK ( GO TO ACTION URL );
+				if ( self.layout!='full' && self.action && self.action.type=='url' ) {
+					var messageLink = messageEl.querySelector('#td-message-link');
+					messageLink.addEventListener('click', function(e) {
+						tongdao.track('!open_message', { '!message_id': self.mid, '!campaign_id': self.cid });
+					});
+				}
+
+				tongdao.track('!receive_message', { '!message_id': self.mid, '!campaign_id': self.cid });
 
 			}, 100);
 

--- a/app/TdInAppMessage.js
+++ b/app/TdInAppMessage.js
@@ -1,0 +1,327 @@
+define(function() {
+
+	function TdInAppMessage(options) {
+		// IF NO IDs LOG ERROR AND RETURN 
+		if (!options.mid || !options.cid) { 
+			console.log('%cERROR: Message is missing IDs', 'color: #ff0000');
+			return;
+		}
+
+		this.mid = options.mid,
+		this.cid = options.cid,
+		this.html = options.html || '',
+		this.message = options.message || '',
+		this.image_url = options.image_url || '',
+		this.title = options.title || '',
+		this.layout = options.layout || 'top',
+		this.action = options.action || null;
+
+		// MAKE SURE VALUE OF 0 IS NOT SET AS NULL
+		if ( options.display_time === undefined ) {
+			// DEFAULT TO 5 IF LEFT NULL
+			this.display_time = 5;
+		} else {
+			this.display_time = options.display_time;
+		}
+	}
+
+	TdInAppMessage.prototype.createMessageEl = function() {
+
+		var messageEl;
+
+		if ( this.html ){
+
+		} else {
+			
+			messageEl = document.createElement('div');
+			messageEl.id = 'td-popup-message-' + this.cid + this.mid;
+			messageEl.setAttribute( 'class', 'td-popup-message' );
+
+			// SET EACH ELEMENT AS A DOM STRING
+			var imgEl, titleEl, textEl, closeEl;
+
+			imgEl = this.image_url ? '<div id="td-message-image" class="td-message-image"><img src="'+this.image_url+'" /></div>' : '' ;
+			titleEl = this.title ?  '<div id="td-message-title" class="td-message-title">'+this.title+'</div>' : '' ;
+			textEl = '<div id="td-message-text" class="td-message-text">'+this.message+'</div>';
+
+			closeEl = '<div id="td-close-icon"><a class="close-x"></a></div>';
+
+			// SET HTML STRUCTURE OF THE MESSAGE WITH AVAILABLE ELEMENTS
+			messageEl.innerHTML = 
+				'<div id="td-message-container" class="td-message-container">' +
+					imgEl + 
+					'<div id="td-message-body" class="td-message-body">'+
+						titleEl+
+						textEl+
+					'</div>'+
+					closeEl+
+				'</div>';
+		}
+
+		return messageEl;
+
+	}
+
+	TdInAppMessage.prototype.createMessageStyles = function() {
+
+		var messageStyles;
+
+		if (this.layout == 'full') {
+			// CSS STYLES FOR 'FULL' or MIDDLE MESSAGES
+			// TODO:
+
+
+		} else {
+			// CSS STYLES FOR TOP AND BOTTOM MESSAGES
+			messageStyles = {
+				'#td-popup-wrapper-top, #td-popup-wrapper-bottom': { 
+					'width': '400px',
+					'margin-left': '-200px', 
+					'position': 'fixed',
+					'left': '50vw',
+				},
+				'#td-popup-wrapper-top': {
+					'top': '10px'
+				},
+				'#td-popup-wrapper-bottom': {
+					'bottom': '10px'
+				},
+				'.td-popup-message': {
+					'text-align': 'center'
+				},
+				'.td-message-container': { 
+					'opacity': '0',
+					'position': 'relative',
+					'display': 'inline-block',
+					'margin': '5px auto',
+					'text-align': 'left',
+					'border-radius': '10px',
+					'box-sizing': 'border-box',
+					'box-shadow': '0px 0px 40px 0px rgba(0,0,0,0.4)',
+					'transition': 'all ease 0.2s'
+				},
+				// ADDS CLEARFIX FOR FLOAT ELEMENTS
+				'#td-message-container:before, #td-message-container:after': {
+					'display': 'table',
+					'content': '" "'
+				},
+				'#td-message-container:after': {
+					'clear': 'both' 
+				},
+				// SET OPACITY FOR ANIMATION
+				'.td-message-container.active': {
+					'opacity': '1',
+				},
+				'.td-message-container.fade': {
+					'opacity': '0'
+				},
+				'.td-message-image': {
+					'float': 'left',
+					'overflow': 'hidden',
+					'height': '75px',
+					'width': '75px'
+				},
+				'.td-message-image img': {
+					'width': '75px',
+					'height': '75px',
+					'border-radius': '10px 0 0 10px'
+				},
+				'.td-message-body': {
+					'float': 'left',
+					'width': '295px',
+					'padding': '10px',
+					'font-family': 'Trebuchet MS1, Helvetica, sans-serif',
+					'letter-spacing': '0.5px',
+					'color': '#333'
+				},
+				'.td-message-title': {
+					'font-size': '24px',
+					'margin-bottom': '2px'
+				},
+				'.td-message-text': {
+					'font-size': '16px',
+					'line-height': '18px'
+				},
+				'.td-message-title+.td-message-text': {
+					'font-size': '14px',
+					'line-height': '15px',
+					'color': '#666',
+				},
+				'#td-close-icon': {
+					'position': 'absolute',
+					'top': '-10px',
+					'right': '-10px',
+					'height': '25px',
+					'width': '25px'
+				},
+				'.close-x': {
+					'cursor': 'pointer',
+					'font-size': '20px',
+					'border-radius': '50%',
+					'width': '25px',
+					'display': 'inline-block',
+					'height': '25px',
+					'line-height': '24px',
+					'text-align': 'center',
+					'color': '#fff',
+					'background-color': '#999'
+				},
+				'.close-x:hover': {
+					'background-color': '#666'
+				},
+				'.close-x:after': {
+					'content': '"×"'
+				}
+			};
+		}
+
+		return messageStyles;
+	}
+
+	TdInAppMessage.prototype.injectStyles = function(styles) {
+
+        var createStyleText = function(styleDefs) {
+            var st = '';
+            for (var selector in styleDefs) {
+                st += '\n' + selector + ' {';
+                var props = styleDefs[selector];
+                for (var k in props) {
+                    st += k + ':' + props[k] + ';';
+                }
+                st += '}';
+            }
+            return st;
+        };
+
+        // ATTACH STYLES TO DOM
+        var styleText = createStyleText(styles);
+        var headEl = document.head || document.getElementsByTagName('head')[0] || document.documentElement;
+        var styleEl = document.createElement('style');
+
+        headEl.appendChild(styleEl);
+        styleEl.setAttribute('type', 'text/css');
+
+        if (styleEl.styleSheet) { // IE
+            styleEl.styleSheet.cssText = styleText;
+        } else {
+            styleEl.textContent = styleText;
+        }
+
+    }
+
+    TdInAppMessage.prototype.attachMessageEl = function(messageEl, messageWrapper) {
+    	var self = this;
+    	var preLoadImages = function(loadedCallback) {
+    		// IF NONE ATTACH IMAGE
+	        if (!self.image_url) {
+	            loadedCallback();
+	            return;
+	        }
+
+	        var _onload = function() {
+	            loadedCallback();
+	        };
+
+	        var imgObj = new Image();
+	        imgObj.onload = _onload;
+	        imgObj.src = self.image_url;
+	        if (imgObj.complete) {
+	            _onload();
+	        }
+
+	    };
+
+	    var attachMessage = function() {
+	    	// ATTACH MESSAGE ELEMENT TO MESSAGES WRAPPER
+	    	// IF TOP LAYOUT PREPEND TO TOP
+	    	if (self.layout=='top'){
+	    		messageWrapper.insertBefore(messageEl, messageWrapper.childNodes[0]);
+	    	} else {
+	    		// ELSE APPEND TO BOTTOM 
+	    		messageWrapper.appendChild(messageEl);
+	    	}
+			// WAIT FOR DOM ELEMENT TO BE CREATED TO APPLY CSS CLASS -> TRIGGERING ANIMATION
+			var delayClose,
+				messageContainer = messageEl.querySelector('#td-message-container'),
+				msgClosing = false;
+				delay = self.display_time;
+
+			setTimeout( function(){ 
+				_addNewClass(messageContainer, 'active');
+				//SET TIMEOUT ACCORING TO display_time TO FADE OUT AND REMOVE OBJECT
+				_startDelayClose();
+
+				// PREVENT MESSAGE FROM FADING WHILE HOVERED OVER
+				messageEl.addEventListener('mouseenter', function(){
+					msgClosing = false;
+					clearTimeout(delayClose);
+				});
+				// RESTART FADE AFTER LEAVE
+				messageEl.addEventListener('mouseleave', function(){
+					_startDelayClose(); 
+				});
+
+				// ADD HIDE FUNCTION FOR CLOSE BUTTON
+				var closeButton = messageEl.querySelector('#td-close-icon');
+				closeButton.addEventListener('click', function(e){
+					clearTimeout(delayClose);
+					_closeMessage();
+				});
+
+			}, 100);
+
+			var _startDelayClose = function() {
+				// IF DELAY SET TO 0 NEVER CLOSE AUTOMATICALLY
+				if( delay !== 0 ) {
+					// IF NULL OR NOT ZERO SET DELAY TIME IN SECONDS
+					delay = delay || 5;
+					// PREVENT RUNNING DUPLICATE CLOSINGS
+					if(!msgClosing) {
+						delayClose = setTimeout( function(){
+							_closeMessage();
+						}, delay * 1000);
+					}
+				}
+			};
+
+			var _closeMessage = function() {
+				msgClosing = true;
+				_addNewClass( messageContainer, 'fade');
+				// WAIT FOR ANIMATION TIMING 0.2s THEN REMOVE NODE
+				setTimeout( function(){
+					messageWrapper.removeChild(messageEl);
+					if (!messageWrapper.hasChildNodes()) {
+						document.body.removeChild(messageWrapper);
+					}
+				}, 200);
+			};
+
+			//EVENT LISTENER FOR MESSAGE CLICK ( GO TO ACTION URL );
+			if ( self.action && self.action.type=='url' ) {
+				messageContainer.addEventListener('click', function(e) {
+					//STOP FIRING ON CLICKING CLOSE
+					if( e.target != this ) { return; }
+					
+					if(self.new_window){
+						window.open(self.action.value, '_blank');
+					} else {
+						window.location.href = self.action.value;
+					}
+				});
+			}
+
+			var _addNewClass = function(element, className) {
+				var currentClass = element.getAttribute('class');
+				element.setAttribute('class', currentClass+' '+className);
+			};
+
+
+	    };
+
+	    // CHECK FOR IMAGES AND PRELOAD BEFORE ATTACHING
+	    preLoadImages(attachMessage);
+
+    }
+
+	return TdInAppMessage;
+});

--- a/app/TdInAppMessage.js
+++ b/app/TdInAppMessage.js
@@ -6,6 +6,11 @@ define(function() {
 			console.log('%cERROR: Message is missing IDs', 'color: #ff0000');
 			return;
 		}
+		// IF FULL CENTERED MESSAGE WITH NO IMAGE ERROR AND RETURN
+		else if ( options.layout=='full' && !options.image_url ) {
+			console.log('%cERROR: Full layout message missing image', 'color: #ff0000');
+			return;
+		}
 
 		this.mid = options.mid,
 		this.cid = options.cid,
@@ -14,8 +19,8 @@ define(function() {
 		this.image_url = options.image_url || '',
 		this.title = options.title || '',
 		this.layout = options.layout || 'top',
-		this.action = options.action || null;
-
+		this.action = options.action || null,
+		this.buttons = options.buttons || [];
 		// MAKE SURE VALUE OF 0 IS NOT SET AS NULL
 		if ( options.display_time === undefined ) {
 			// DEFAULT TO 5 IF LEFT NULL
@@ -23,6 +28,150 @@ define(function() {
 		} else {
 			this.display_time = options.display_time;
 		}
+
+		// CSS ELEMENT FOR ALL MESSAGES
+		this.messageStyles = {
+			'#td-popup-wrapper-full': {
+				'position': 'fixed',
+				'top': '50%',
+				'left': '50%',
+				'transform': 'translate(-50%, -50%)',
+				'z-index': '999'
+			},
+			'#td-popup-wrapper-top, #td-popup-wrapper-bottom': { 
+				'width': '400px',
+				'margin-left': '-200px', 
+				'position': 'fixed',
+				'left': '50vw',
+			},
+			'#td-popup-wrapper-top': {
+				'top': '10px'
+			},
+			'#td-popup-wrapper-bottom': {
+				'bottom': '10px'
+			},
+			'.td-popup-message': {
+				'text-align': 'center'
+			},
+			// TOP AND BOTTOM LAYOUT
+			'.td-message-container': { 
+				'opacity': '0',
+				'position': 'relative',
+				'display': 'inline-block',
+				'margin': '5px auto',
+				'text-align': 'left',
+				'border-radius': '5px',
+				'box-sizing': 'border-box',
+				'box-shadow': '0px 0px 40px 0px rgba(0,0,0,0.4)',
+				'transition': 'all ease 0.2s',
+				'vertical-align': 'middle',
+			},
+			'div.td-message-container': {
+				'cursor': 'default'
+			},
+			// ADDS CLEARFIX FOR FLOAT ELEMENTS
+			'#td-message-container:before, #td-message-container:after': {
+				'display': 'table',
+				'content': '" "'
+			},
+			'#td-message-container:after': {
+				'clear': 'both' 
+			},
+			'.td-message-container.active': {
+				'opacity': '1',
+			},
+			'.td-message-container.fade': {
+				'opacity': '0'
+			},
+			'.td-message-link': {
+				'display': 'inline-block',
+				'vertical-align': 'middle'
+			},
+			'.td-message-image': {
+				'float': 'left',
+				'overflow': 'hidden',
+				'height': '75px',
+				'width': '75px'
+			},
+			'.td-message-image img': {
+				'width': '75px',
+				'height': '75px',
+				'border-radius': '5px 0 0 5px'
+			},
+			'.td-message-body': {
+				'float': 'left',
+				'width': '295px',
+				'padding': '10px',
+				'font-family': 'Trebuchet MS1, Helvetica, sans-serif',
+				'letter-spacing': '0.5px',
+				'color': '#333'
+			},
+			'.td-message-title': {
+				'font-size': '24px',
+				'margin-bottom': '2px'
+			},
+			'.td-message-text': {
+				'font-size': '16px',
+				'line-height': '18px'
+			},
+			'.td-message-title+.td-message-text': {
+				'font-size': '14px',
+				'line-height': '15px',
+				'color': '#666',
+			},
+			// FULL LAYOUT MESSAGE
+			'.td-message-cover': {
+				'opacity': '0',
+				'position': 'relative',
+				'display': 'inline-block',
+				'text-align': 'left',
+				'border-radius': '5px',
+				'box-sizing': 'border-box',
+				'box-shadow': '0px 0px 40px 0px rgba(0,0,0,0.4)',
+				'transition': 'all ease 0.2s'
+			},
+			'.td-message-cover img': {
+				'max-width': '100%',
+				'min-height': '100%',
+				'border-radius': '5px',
+				'vertical-align': 'middle'
+			},
+			'.td-message-cover.active': {
+				'opacity': '1',
+			},
+			'.td-message-cover.fade': {
+				'opacity': '0'
+			},
+			'.td-message-button': {
+				'position': 'absolute',
+			},
+			// CLOSE BUTTON
+			'#td-close-icon': {
+				'position': 'absolute',
+				'top': '-7px',
+				'right': '-7px',
+				'height': '20px',
+				'width': '20px'
+			},
+			'.close-x': {
+				'cursor': 'pointer',
+				'font-size': '18px',
+				'border-radius': '50%',
+				'width': '21px',
+				'display': 'inline-block',
+				'height': '21px',
+				'line-height': '18px',
+				'text-align': 'center',
+				'color': '#fff',
+				'background-color': '#666'
+			},
+			'.close-x:hover': {
+				'background-color': '#333'
+			},
+			'.close-x:after': {
+				'content': '"×"'
+			}
+		};
 	}
 
 	TdInAppMessage.prototype.createMessageEl = function() {
@@ -37,148 +186,53 @@ define(function() {
 			messageEl.id = 'td-popup-message-' + this.cid + this.mid;
 			messageEl.setAttribute( 'class', 'td-popup-message' );
 
-			// SET EACH ELEMENT AS A DOM STRING
-			var imgEl, titleEl, textEl, closeEl;
+			// SET EACH ELEMENT AS A DOM STRING AND INJECT TO messageEl
+			if (this.layout=='full') {
 
-			imgEl = this.image_url ? '<div id="td-message-image" class="td-message-image"><img src="'+this.image_url+'" /></div>' : '' ;
-			titleEl = this.title ?  '<div id="td-message-title" class="td-message-title">'+this.title+'</div>' : '' ;
-			textEl = '<div id="td-message-text" class="td-message-text">'+this.message+'</div>';
+				// CREATE BUTTONS WITH INLINE STYLING
+				buttonEls = [];
+				var createButton = function( item, index ) {
+					var buttonEl = '<a id="td-message-button-' + index + '" class="td-message-button" href="' + item.action.value + '" style="left: '+item.left+'px; top: '+item.top+'px; height: '+item.height+'px; width: '+item.width+'px;"></a>';
+					buttonEls.push(buttonEl);
+				};
 
-			closeEl = '<div id="td-close-icon"><a class="close-x"></a></div>';
+				this.buttons.forEach( createButton );
 
-			// SET HTML STRUCTURE OF THE MESSAGE WITH AVAILABLE ELEMENTS
-			messageEl.innerHTML = 
-				'<div id="td-message-container" class="td-message-container">' +
-					imgEl + 
-					'<div id="td-message-body" class="td-message-body">'+
-						titleEl+
-						textEl+
-					'</div>'+
-					closeEl+
-				'</div>';
+				var button1 = buttonEls[0] ? buttonEls[0] : '',
+					button2 = buttonEls[1] ? buttonEls[1] : '', 
+					imgEl = '<img src="' + this.image_url + '" />',
+					closeEl = '<div id="td-close-icon"><a class="close-x"></a></div>';
+
+				messageEl.innerHTML = 
+					'<div id="td-message-cover" class="td-message-cover">' + 
+						imgEl +
+						button1 +
+						button2 + 
+						closeEl +
+					'</div>'
+
+			} else {
+				var imgEl = this.image_url ? '<div id="td-message-image" class="td-message-image"><img src="' + this.image_url + '" /></div>' : '',
+					titleEl = this.title ?  '<div id="td-message-title" class="td-message-title">' + this.title + '</div>' : '',
+					textEl = '<div id="td-message-text" class="td-message-text">' + this.message + '</div>',
+					bodyEl = '<div id="td-message-body" class="td-message-body">'+ titleEl + textEl + '</div>',
+					closeEl = '<div id="td-close-icon"><div class="close-x"></div></div>',
+					
+					// IF MESSAGE HAS ACTION > WRAP ALL BUT CLOSE IN <a>
+					innerMessage = ( this.action&&this.action.type=='url' ) ?
+					'<a href="' + this.action.value +'" class="td-message-link">' + imgEl + bodyEl + '</a>' + closeEl: imgEl + bodyEl + closeEl ;
+
+				// WRAP IN MSG CONTAINER AND SET AS innerHTML
+				messageEl.innerHTML = '<div id="td-message-container" class="td-message-container">' + innerMessage + '</div>';
+			}
+
 		}
 
 		return messageEl;
 
 	}
 
-	TdInAppMessage.prototype.createMessageStyles = function() {
-
-		var messageStyles;
-
-		if (this.layout == 'full') {
-			// CSS STYLES FOR 'FULL' or MIDDLE MESSAGES
-			// TODO:
-
-
-		} else {
-			// CSS STYLES FOR TOP AND BOTTOM MESSAGES
-			messageStyles = {
-				'#td-popup-wrapper-top, #td-popup-wrapper-bottom': { 
-					'width': '400px',
-					'margin-left': '-200px', 
-					'position': 'fixed',
-					'left': '50vw',
-				},
-				'#td-popup-wrapper-top': {
-					'top': '10px'
-				},
-				'#td-popup-wrapper-bottom': {
-					'bottom': '10px'
-				},
-				'.td-popup-message': {
-					'text-align': 'center'
-				},
-				'.td-message-container': { 
-					'opacity': '0',
-					'position': 'relative',
-					'display': 'inline-block',
-					'margin': '5px auto',
-					'text-align': 'left',
-					'border-radius': '10px',
-					'box-sizing': 'border-box',
-					'box-shadow': '0px 0px 40px 0px rgba(0,0,0,0.4)',
-					'transition': 'all ease 0.2s'
-				},
-				// ADDS CLEARFIX FOR FLOAT ELEMENTS
-				'#td-message-container:before, #td-message-container:after': {
-					'display': 'table',
-					'content': '" "'
-				},
-				'#td-message-container:after': {
-					'clear': 'both' 
-				},
-				// SET OPACITY FOR ANIMATION
-				'.td-message-container.active': {
-					'opacity': '1',
-				},
-				'.td-message-container.fade': {
-					'opacity': '0'
-				},
-				'.td-message-image': {
-					'float': 'left',
-					'overflow': 'hidden',
-					'height': '75px',
-					'width': '75px'
-				},
-				'.td-message-image img': {
-					'width': '75px',
-					'height': '75px',
-					'border-radius': '10px 0 0 10px'
-				},
-				'.td-message-body': {
-					'float': 'left',
-					'width': '295px',
-					'padding': '10px',
-					'font-family': 'Trebuchet MS1, Helvetica, sans-serif',
-					'letter-spacing': '0.5px',
-					'color': '#333'
-				},
-				'.td-message-title': {
-					'font-size': '24px',
-					'margin-bottom': '2px'
-				},
-				'.td-message-text': {
-					'font-size': '16px',
-					'line-height': '18px'
-				},
-				'.td-message-title+.td-message-text': {
-					'font-size': '14px',
-					'line-height': '15px',
-					'color': '#666',
-				},
-				'#td-close-icon': {
-					'position': 'absolute',
-					'top': '-10px',
-					'right': '-10px',
-					'height': '25px',
-					'width': '25px'
-				},
-				'.close-x': {
-					'cursor': 'pointer',
-					'font-size': '20px',
-					'border-radius': '50%',
-					'width': '25px',
-					'display': 'inline-block',
-					'height': '25px',
-					'line-height': '24px',
-					'text-align': 'center',
-					'color': '#fff',
-					'background-color': '#999'
-				},
-				'.close-x:hover': {
-					'background-color': '#666'
-				},
-				'.close-x:after': {
-					'content': '"×"'
-				}
-			};
-		}
-
-		return messageStyles;
-	}
-
-	TdInAppMessage.prototype.injectStyles = function(styles) {
+	TdInAppMessage.prototype.injectStyles = function() {
 
         var createStyleText = function(styleDefs) {
             var st = '';
@@ -194,9 +248,10 @@ define(function() {
         };
 
         // ATTACH STYLES TO DOM
-        var styleText = createStyleText(styles);
+        var styleText = createStyleText(this.messageStyles);
         var headEl = document.head || document.getElementsByTagName('head')[0] || document.documentElement;
         var styleEl = document.createElement('style');
+        styleEl.id = 'td-message-styles';
 
         headEl.appendChild(styleEl);
         styleEl.setAttribute('type', 'text/css');
@@ -211,15 +266,18 @@ define(function() {
 
     TdInAppMessage.prototype.attachMessageEl = function(messageEl, messageWrapper) {
     	var self = this;
-    	var preLoadImages = function(loadedCallback) {
+    	var preLoadImages = function() {
     		// IF NONE ATTACH IMAGE
 	        if (!self.image_url) {
-	            loadedCallback();
+	            attachMessage();
 	            return;
 	        }
 
 	        var _onload = function() {
-	            loadedCallback();
+	        	// SAVE IMAGE H & W > IF NONE FOUND SET DEFAULT TO TD MESSAGE CREATOR DEFAULT
+        		self.image_h = imgObj.height ? imgObj.height : self.is_portrait ? 406 : 256;
+        		self.image_w = imgObj.width ? imgObj.width : self.is_portrait ? 256 : 406;
+        		attachMessage();
 	        };
 
 	        var imgObj = new Image();
@@ -242,44 +300,20 @@ define(function() {
 	    	}
 			// WAIT FOR DOM ELEMENT TO BE CREATED TO APPLY CSS CLASS -> TRIGGERING ANIMATION
 			var delayClose,
-				messageContainer = messageEl.querySelector('#td-message-container'),
 				msgClosing = false;
-				delay = self.display_time;
 
-			setTimeout( function(){ 
-				_addNewClass(messageContainer, 'active');
-				//SET TIMEOUT ACCORING TO display_time TO FADE OUT AND REMOVE OBJECT
-				_startDelayClose();
-
-				// PREVENT MESSAGE FROM FADING WHILE HOVERED OVER
-				messageEl.addEventListener('mouseenter', function(){
-					msgClosing = false;
-					clearTimeout(delayClose);
-				});
-				// RESTART FADE AFTER LEAVE
-				messageEl.addEventListener('mouseleave', function(){
-					_startDelayClose(); 
-				});
-
-				// ADD HIDE FUNCTION FOR CLOSE BUTTON
-				var closeButton = messageEl.querySelector('#td-close-icon');
-				closeButton.addEventListener('click', function(e){
-					clearTimeout(delayClose);
-					_closeMessage();
-				});
-
-			}, 100);
+			// IF FULL SELECT COVER ELEMENT OTHERWISE CONTAINER
+			var messageContainer = self.layout=='full' ? messageEl.querySelector('#td-message-cover') :
+				messageEl.querySelector('#td-message-container');
 
 			var _startDelayClose = function() {
 				// IF DELAY SET TO 0 NEVER CLOSE AUTOMATICALLY
-				if( delay !== 0 ) {
-					// IF NULL OR NOT ZERO SET DELAY TIME IN SECONDS
-					delay = delay || 5;
+				if( self.display_time > 0 ) {
 					// PREVENT RUNNING DUPLICATE CLOSINGS
 					if(!msgClosing) {
 						delayClose = setTimeout( function(){
 							_closeMessage();
-						}, delay * 1000);
+						}, self.display_time * 1000);
 					}
 				}
 			};
@@ -295,31 +329,49 @@ define(function() {
 					}
 				}, 200);
 			};
-
-			//EVENT LISTENER FOR MESSAGE CLICK ( GO TO ACTION URL );
-			if ( self.action && self.action.type=='url' ) {
-				messageContainer.addEventListener('click', function(e) {
-					//STOP FIRING ON CLICKING CLOSE
-					if( e.target != this ) { return; }
-					
-					if(self.new_window){
-						window.open(self.action.value, '_blank');
-					} else {
-						window.location.href = self.action.value;
-					}
-				});
-			}
-
 			var _addNewClass = function(element, className) {
 				var currentClass = element.getAttribute('class');
 				element.setAttribute('class', currentClass+' '+className);
 			};
 
+			var _setButtonPositions = function() {
+
+		    };
+
+		    // IF LAYOUT FULL SET VERTICAL HEIGHT AND BUTTONS BEFORESHOWING
+		    if ( self.layout == 'full' ) {
+		    	messageWrapper.setAttribute('style', 'height: '+ self.image_h +'px; width: '+ self.image_w +'px;' );
+		    	_setButtonPositions();
+		    }
+
+			setTimeout( function(){ 
+				_addNewClass(messageContainer, 'active');
+				//SET TIMEOUT ACCORING TO display_time TO FADE OUT AND REMOVE OBJECT
+				_startDelayClose();
+
+				// PREVENT MESSAGE FROM FADING WHILE HOVERED OVER
+				messageContainer.addEventListener('mouseenter', function(){
+					msgClosing = false;
+					clearTimeout(delayClose);
+				});
+				// RESTART FADE AFTER LEAVE
+				messageContainer.addEventListener('mouseleave', function(){
+					_startDelayClose(); 
+				});
+
+				// ADD HIDE FUNCTION FOR CLOSE BUTTON
+				var closeButton = messageEl.querySelector('#td-close-icon');
+				closeButton.addEventListener('click', function(e){
+					clearTimeout(delayClose);
+					_closeMessage();
+				});
+
+			}, 100);
 
 	    };
 
 	    // CHECK FOR IMAGES AND PRELOAD BEFORE ATTACHING
-	    preLoadImages(attachMessage);
+	    preLoadImages();
 
     }
 

--- a/app/TongDao.js
+++ b/app/TongDao.js
@@ -501,25 +501,34 @@ function(DEFAULT_OPTIONS, Cookie, UUID, UAParser, Request, Validator, TdOrder, T
 			// LOOPS THROUGH MESSAGES WITH SLIGHT DELAY
 			var messageLength = msgData.length;
 			var counter = 0;
+			var firstFull = true;
 			(function displayMsg (i) {            
 				// CREATE NEW tdMessage WITH CORRESPONDING DATA
 				var tdMessage = new TdInAppMessage(msgData[i]);
 
 				// CHECK FOR CORRESPONDING POSITION'S MESSAGES WRAPPER AND CREATE IF NONE
-				var tdWrapper = document.getElementById('td-popup-wrapper-' + tdMessage.layout)	
+				var tdWrapper = document.getElementById('td-popup-wrapper-' + tdMessage.layout);
 				if (!tdWrapper) {
 					tdWrapper = document.createElement('div');
 					tdWrapper.id = 'td-popup-wrapper-' + tdMessage.layout;
 					document.body.appendChild(tdWrapper);
 				}
 
-				// CREATE MESSAGE AND CSS STYLE DOM ELEMENTS
+				// CREATE MESSAGE ELEMENTS
 				var messageEl = tdMessage.createMessageEl();
-				var messageStyles = tdMessage.createMessageStyles();
-				// ADD CSS ELEMENT
-				tdMessage.injectStyles(messageStyles);
-				// PRELOAD IMAGES AND ATTACH MESSAGE TO DOM
-				tdMessage.attachMessageEl(messageEl, tdWrapper);
+
+				// CHECK FOR MESSAGES CSS, IF NONE INJECT CSS STYLE NODE
+				if ( !document.getElementById('td-message-styles') ) {
+					tdMessage.injectStyles();
+				}
+
+				// CHECK IF FIRST "full" LAYOUR MESSAGE > PREVENT MORE THAN ONE FROM ATTACHING
+				if( tdMessage.layout!='full' || firstFull ) {
+					if(tdMessage.layout=='full') firstFull = false;
+					// PRELOAD IMAGES AND ATTACH MESSAGE TO DOM
+					tdMessage.attachMessageEl(messageEl, tdWrapper);
+				};
+				
 				// DELAY NEXT MESSAGE ATTACHMENT FOR BETTER UI
 				counter++;
 				if (counter<messageLength) {
@@ -529,7 +538,7 @@ function(DEFAULT_OPTIONS, Cookie, UUID, UAParser, Request, Validator, TdOrder, T
 				}
 			})(counter); 
 
-		});
+		} );
 
 	}
 

--- a/app/TongDao.js
+++ b/app/TongDao.js
@@ -201,7 +201,7 @@ function(DEFAULT_OPTIONS, Cookie, UUID, UAParser, Request, Validator, TdOrder, T
 					action: event.action,
 					user_id: options.userId || options.deviceId,
 					properties: eventProperties,
-					timestamp: new Date().toISOString()
+					timestamp: getISOString()
 				}
 				for(var prop in userProperties) {
 					if(userProperties.hasOwnProperty(prop)) {
@@ -217,6 +217,25 @@ function(DEFAULT_OPTIONS, Cookie, UUID, UAParser, Request, Validator, TdOrder, T
 		} catch (e) {
 			_log( '_logEvents: ' + e);
 		}
+	}
+
+	function pad(number) {
+		if (number < 10) {
+			return '0' + number;
+		}
+		return number;
+	}
+
+	function getISOString() {
+		var d = new Date();
+		return d.getUTCFullYear() +
+			'-' + pad(d.getUTCMonth() + 1) +
+			'-' + pad(d.getUTCDate()) +
+			'T' + pad(d.getUTCHours()) +
+			':' + pad(d.getUTCMinutes()) +
+			':' + pad(d.getUTCSeconds()) +
+			'.' + (d.getUTCMilliseconds() / 1000).toFixed(3).slice(2, 5) +
+		'Z';
 	}
 
 	function _logEvent(action, eventType, eventProperties, callback) {

--- a/app/TongDao.js
+++ b/app/TongDao.js
@@ -488,13 +488,13 @@ function(DEFAULT_OPTIONS, Cookie, UUID, UAParser, Request, Validator, TdOrder, T
 		track('!place_order', order);
 	}
 
-	function displayInAppMessage() {
+	function displayInAppMessage(callback) {
 
 		// FETCH MESSAGES DATA AND THEN CREATE AND ATTACH RETURNED MESSAGES
 		checkForInAppMessage( function( msgData ) {
 			// RETURN IF NO MESSAGES
 			if (!msgData.length) {
-				console.log('No Messages Found');
+				if (callback) callback();
 				return;
 			}
 
@@ -535,6 +535,8 @@ function(DEFAULT_OPTIONS, Cookie, UUID, UAParser, Request, Validator, TdOrder, T
 					setTimeout(function () { 
 						displayMsg(counter);
 					}, 800);
+				} else {
+					if (callback) callback();
 				}
 			})(counter); 
 
@@ -548,6 +550,10 @@ function(DEFAULT_OPTIONS, Cookie, UUID, UAParser, Request, Validator, TdOrder, T
 		var userId = options.userId || options.deviceId;
 		var url = 'https://api.tongrd.com/v2/messages?user_id=' + userId;
 		var appKey = options.appKey;
+		
+		// CHECK FOR REQUIRED userId
+		if ( !userId ) { throw( 'Error: Missing User Id' ); return; }
+
 		var async = true;
 		if(options.async !== undefined && options.async !== null) {
 			async = !!options.async;
@@ -563,21 +569,10 @@ function(DEFAULT_OPTIONS, Cookie, UUID, UAParser, Request, Validator, TdOrder, T
 						return JSON.parse(response);
 					};
 				} else {
-					// _returnEventsToUnsent(data.events);
-					// if (status === 413) {
-					// 	_log('Request too large');
-					// 	if (options.uploadBatchSize === 1) {
-					// 		unsentEvents.splice(0, 1);
-					// 	}
-					// 	options.uploadBatchSize = Math.ceil(numEvents / 2);
-					// 	sendEvents(callback);
-					// } else if (callback) {
-					// 	_log('Unhandled error ' + status);
-					// 	callback(status, response);
-					// }
+					_log(' Unable to Return messages');
 				}
 			} catch (e) {
-				_log('Unable to Get Messages' + e);
+				_log(' Unable to Get Messages: ' + e);
 			}
 		});
 	}

--- a/app/TongDao.js
+++ b/app/TongDao.js
@@ -262,7 +262,7 @@ function(DEFAULT_OPTIONS, Cookie, UUID, UAParser, Request, Validator, TdOrder, T
 		var data = {
 			events: _pollEventsToSend()
 		};
-		new Request(url, data, appKey, async).post(function(status, response) {
+		new Request('POST', url, data, appKey, async).send(function(status, response) {
 			try {
 				if (status === 204 || status === 200) {
 					sendEvents(callback);


### PR DESCRIPTION
Added basic notifications for InApp messages

2 functions added tongdao.checkForInAppMessage() & tongdao.displayInAppMessage(): 
- checkForInAppMessage: will call API with userId ( or defaults to deviceId in case of JS ) to fetch messages and return array
- displayInAppMessage: will run checkForInAppMessage and on successful fetch create and display DOM elements with event listeners for each message
- Covers 3 layout types, Top, Bottom, and Full.
- Each notification on display will fire !received_message event.
- On click, message with fire !open_message event.
